### PR TITLE
Force GO build tracing mode

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,8 +21,8 @@ on:
     - cron: '30 8 * * 6'
   workflow_dispatch:
   
-env:
-  CODEQL_EXTRACTOR_GO_BUILD_TRACING: on
+#env:
+#  CODEQL_EXTRACTOR_GO_BUILD_TRACING: on
 
 jobs:
   analyze:
@@ -71,8 +71,8 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    - run: |
-       go build
+    #- run: |
+    #   go build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,8 +21,8 @@ on:
     - cron: '30 8 * * 6'
   workflow_dispatch:
   
-#env:
-#  CODEQL_EXTRACTOR_GO_BUILD_TRACING: on
+env:
+  CODEQL_EXTRACTOR_GO_BUILD_TRACING: on
 
 jobs:
   analyze:
@@ -71,8 +71,8 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    #- run: |
-    #   go build
+    - run: |
+       go build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,9 @@ on:
   schedule:
     - cron: '30 8 * * 6'
   workflow_dispatch:
+  
+env:
+  CODEQL_EXTRACTOR_GO_BUILD_TRACING: on
 
 jobs:
   analyze:
@@ -59,7 +62,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.15
+        go-version: 1.18.x
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -68,15 +71,15 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - run: |
+       go build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
 
-    - name: Upload Artifacts to Workflow
-      uses: actions/upload-artifact@v3
-      with:
-        #ex: 2022-05-01T22:50:51.5782478Z Processing sarif files: ["/home/runner/work/felickz-ghas-bootcamp/results/python.sarif"]        
-        path: ${{ github.workspace }}/../results/*.sarif
+    #- name: Upload Artifacts to Workflow
+    #  uses: actions/upload-artifact@v3
+    #  with:
+    #    #ex: 2022-05-01T22:50:51.5782478Z Processing sarif files: ["/home/runner/work/felickz-ghas-bootcamp/results/python.sarif"]        
+    #    # cannot use .. 
+    #    path: ${{ github.workspace }}/../results/*.sarif

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,8 +21,8 @@ on:
     - cron: '30 8 * * 6'
   workflow_dispatch:
   
-env:
-  CODEQL_EXTRACTOR_GO_BUILD_TRACING: on
+#env:
+#  CODEQL_EXTRACTOR_GO_BUILD_TRACING: on
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,8 +21,8 @@ on:
     - cron: '30 8 * * 6'
   workflow_dispatch:
   
-#env:
-#  CODEQL_EXTRACTOR_GO_BUILD_TRACING: on
+env:
+  CODEQL_EXTRACTOR_GO_BUILD_TRACING: on
 
 jobs:
   analyze:
@@ -77,9 +77,8 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
 
-    #- name: Upload Artifacts to Workflow
-    #  uses: actions/upload-artifact@v3
-    #  with:
-    #    #ex: 2022-05-01T22:50:51.5782478Z Processing sarif files: ["/home/runner/work/felickz-ghas-bootcamp/results/python.sarif"]        
-    #    # cannot use .. 
-    #    path: ${{ github.workspace }}/../results/*.sarif
+    - name: Upload Artifacts to Workflow
+      uses: actions/upload-artifact@v3
+      with:
+        #ex: 2022-05-01T22:50:51.5782478Z Processing sarif files: ["/home/runner/work/felickz-ghas-bootcamp/results/python.sarif"]        
+        path: ${{ runner.workspace }}/results/*.sarif


### PR DESCRIPTION
Testing go build tracing mode! See gist: https://gist.github.com/felickz/19d297067c5cb217531362c34194749f
- project is so small ... timings are likely irrelevant

# Autobuild (1m56s)
Init - 8s
Analyze - 1m 26s

> env:
>     CODEQL_ACTION_RUN_MODE: Action
>     CODEQL_ACTION_VERSION: 2.1.21
>     CODEQL_ACTION_FEATURE_SARIF_COMBINE: true
>     CODEQL_ACTION_FEATURE_WILL_UPLOAD: true
>     CODEQL_ACTION_ANALYSIS_KEY: .github/workflows/codeql-analysis.yml:analyze
>     CODEQL_WORKFLOW_STARTED_AT: 2022-08-26T15:09:52.[17](https://github.com/octodemo/felickz-advanced-security-go/runs/8039248938?check_suite_focus=true#step:5:17)8Z
>     CODEQL_ACTION_FEATURE_MULTI_LANGUAGE: false
>     CODEQL_ACTION_FEATURE_SANDWICH: false
>     CODEQL_RAM: 59[19](https://github.com/octodemo/felickz-advanced-security-go/runs/8039248938?check_suite_focus=true#step:5:19)
>     CODEQL_THREADS: 2
> /opt/hostedtoolcache/CodeQL/0.0.0-[20](https://github.com/octodemo/felickz-advanced-security-go/runs/8039248938?check_suite_focus=true#step:5:20)[22](https://github.com/octodemo/felickz-advanced-security-go/runs/8039248938?check_suite_focus=true#step:5:22)0811/x64/codeql/codeql version --format=terse
> 2.10.3
> Extracting go
> Finalizing go
> Running queries for go
> Interpreting results for go
> Analysis produced the following diagnostic data:
> 
> |         Diagnostic          |  Summary  |
> +-----------------------------+-----------+
> | Successfully analyzed files | 3 results |
> 
> Analysis produced the following metric data:
> 
> |                 Metric                 | Value |
> +----------------------------------------+-------+
> | Total lines of Go code in the database |   161 |
> 
> 
> /opt/hostedtoolcache/CodeQL/0.0.0-20220811/x64/codeql/codeql database print-baseline /home/runner/work/_temp/codeql_databases/go
> Counted a baseline of 161 lines of code for go.
> Counted a baseline of 161 lines of code for go.
> 

# Tracing Mode On (3m9s)

Init - 11s
Go Build - 1m 49s
Analyze - 40s

env:
>    CODEQL_EXTRACTOR_GO_BUILD_TRACING: on
>     CODEQL_ACTION_RUN_MODE: Action
>     CODEQL_ACTION_VERSION: 2.1.21
>     CODEQL_ACTION_FEATURE_SARIF_COMBINE: true
>     CODEQL_ACTION_FEATURE_WILL_UPLOAD: true
>     CODEQL_ACTION_ANALYSIS_KEY: .github/workflows/codeql-analysis.yml:analyze
>     CODEQL_WORKFLOW_STARTED_AT: 2022-08-26T15:03:06.[18](https://github.com/octodemo/felickz-advanced-security-go/runs/8039117142?check_suite_focus=true#step:6:18)9Z
>     CODEQL_ACTION_FEATURE_MULTI_LANGUAGE: false
>     CODEQL_ACTION_FEATURE_SANDWICH: false
>     CODEQL_RAM: 59[19](https://github.com/octodemo/felickz-advanced-security-go/runs/8039117142?check_suite_focus=true#step:6:19)
>     CODEQL_THREADS: 2
>     CODEQL_TRACER_LOG: /home/runner/work/_temp/codeql_databases/log/build-tracer.log
>     CODEQL_TRACER_LANGUAGES: go
>     SEMMLE_PRELOAD_libtrace: /opt/hostedtoolcache/CodeQL/0.0.0-[20](https://github.com/octodemo/felickz-advanced-security-go/runs/8039117142?check_suite_focus=true#step:6:20)[22](https://github.com/octodemo/felickz-advanced-security-go/runs/8039117142?check_suite_focus=true#step:6:22)0811/x64/codeql/tools/linux64/${LIB}_${PLATFORM}_trace.so
>     SEMMLE_PRELOAD_libtrace32: /opt/hostedtoolcache/CodeQL/0.0.0-20220811/x64/codeql/tools/linux64/lib32trace.so
>     SEMMLE_PRELOAD_libtrace64: /opt/hostedtoolcache/CodeQL/0.0.0-20220811/x64/codeql/tools/linux64/lib64trace.so
>     CODEQL_PLATFORM: linux64
>     CODEQL_DIST: /opt/hostedtoolcache/CodeQL/0.0.0-20220811/x64/codeql
>     CODEQL_SCRATCH_DIR: /home/runner/work/_temp/codeql_databases/working
>     CODEQL_PLATFORM_DLL_EXTENSION: .so
>     CODEQL_JAVA_HOME: /opt/hostedtoolcache/CodeQL/0.0.0-20220811/x64/codeql/tools/linux64/java
>     CODEQL_EXTRACTOR_GO_ROOT: /opt/hostedtoolcache/CodeQL/0.0.0-20220811/x64/codeql/go
>     CODEQL_EXTRACTOR_GO_WIP_DATABASE: /home/runner/work/_temp/codeql_databases/go
>     CODEQL_EXTRACTOR_GO_LOG_DIR: /home/runner/work/_temp/codeql_databases/go/log
>     CODEQL_EXTRACTOR_GO_SCRATCH_DIR: /home/runner/work/_temp/codeql_databases/go/working
>     CODEQL_EXTRACTOR_GO_TRAP_DIR: /home/runner/work/_temp/codeql_databases/go/trap/go
>     CODEQL_EXTRACTOR_GO_SOURCE_ARCHIVE_DIR: /home/runner/work/_temp/codeql_databases/go/src
>     CODEQL_EXTRACTOR_GO_THREADS: 2
>     CODEQL_EXTRACTOR_GO_RAM: 5919
>     LD_PRELOAD: /opt/hostedtoolcache/CodeQL/0.0.0-20220811/x64/codeql/tools/linux64/${LIB}_${PLATFORM}_trace.so
>     CODEQL_RUNNER: /opt/hostedtoolcache/CodeQL/0.0.0-20220811/x64/codeql/tools/linux64/runner
> /opt/hostedtoolcache/CodeQL/0.0.0-20220811/x64/codeql/codeql version --format=terse
> 2.10.3
> Finalizing go
> Running queries for go
> Interpreting results for go
> Analysis produced the following diagnostic data:
> 
> |         Diagnostic          |  Summary  |
> +-----------------------------+-----------+
> | Successfully analyzed files | 3 results |
> 
> Analysis produced the following metric data:
> 
> |                 Metric                 | Value |
> +----------------------------------------+-------+
> | Total lines of Go code in the database |   161 |
> 
> 
> /opt/hostedtoolcache/CodeQL/0.0.0-20220811/x64/codeql/codeql database print-baseline /home/runner/work/_temp/codeql_databases/go
> Counted a baseline of 161 lines of code for go.
> Counted a baseline of 161 lines of code for go.