### PR TITLE
Test paths-ignore with GO autobuilder

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+name: "My CodeQL config"
+
+paths-ignore: 
+  - modules  

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,6 +46,7 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
+        config-file: ./.github/codeql/codeql-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -80,4 +80,4 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         #ex: 2022-05-01T22:50:51.5782478Z Processing sarif files: ["/home/runner/work/felickz-ghas-bootcamp/results/python.sarif"]        
-        path: ${{ github.workspace }}/../results/*.sarif
+        path: ${{ runner.workspace }}/../results/*.sarif

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -80,4 +80,4 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         #ex: 2022-05-01T22:50:51.5782478Z Processing sarif files: ["/home/runner/work/felickz-ghas-bootcamp/results/python.sarif"]        
-        path: ${{ runner.workspace }}/../results/*.sarif
+        path: ${{ runner.workspace }}/results/*.sarif


### PR DESCRIPTION
Testing GO default "scraping mode" to see if paths ignore impacts the files scanned... (docs do not indicate this is true)

[Specifying directories to scan](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#specifying-directories-to-scan)
For the interpreted languages that CodeQL supports (Python, Ruby and JavaScript/TypeScript), (edited)


# Results

Analyze (go)The "paths"/"paths-ignore" fields of the config only have effect for JavaScript, Python, and Ruby
